### PR TITLE
Adds Py3 compatibility via six.

### DIFF
--- a/requery/views.py
+++ b/requery/views.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Create your views here.
 import json
+import six
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
@@ -8,7 +9,10 @@ from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.template.defaultfilters import safe
-from django.utils.encoding import force_unicode
+if six.PY3:
+    from django.utils.encoding import force_text
+else:
+    from django.utils.encoding import force_unicode as force_text
 from requery.forms import QueryForm
 from requery.models import Query
 from django.db import connections
@@ -18,7 +22,7 @@ def form_query(request, query_id):
     query = Query.objects.get(id=query_id)
     form = QueryForm(initial={'text':query.text}, query=query)
     context = {
-        'title': 'Run Query %s on database %s' % (force_unicode(query.name), query.database),
+        'title': 'Run Query %s on database %s' % (force_text(query.name), query.database),
         'form': form,
         'object_id': query_id,
         'original': query,
@@ -45,7 +49,7 @@ def run_query(request, query_id):
         cursor.execute(text, params)
         lines = []
         for line in cursor.fetchall():
-            lines.append([unicode(tup) for tup in line])
+            lines.append([six.text_type(tup) for tup in line])
 
         if lines :
             response = {
@@ -62,7 +66,7 @@ def run_query(request, query_id):
         LogEntry(user=request.user,
                  content_type=ContentType.objects.get_for_model(query),
                  object_id=query.id,
-                 object_repr=force_unicode(query),
+                 object_repr=force_text(query),
                  change_message="run with %s" % ', '.join(['%s:%s' % (key, value)
                                                  for key, value in request.POST.items()
                                                  if key != 'csrfmiddlewaretoken']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django==1.7
 Pygments==1.6
+six>=1.7

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='http://github.com/ebertti/requery/',
     author='Ezequiel Bertti',
     author_email='ebertti@gmail.com',
-    install_requires=['django>=1.7', 'Pygments>=1.6'],
+    install_requires=['django>=1.7', 'Pygments>=1.6', 'six>=1.7',],
     packages=['requery'],
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Unicode is handled differently in Python3. I've added some checks and switches to make this package compatible with both Python 2 and 3.

Achieves same effect as #7, but uses six. You can choose whichever method you prefer.